### PR TITLE
fix: only open a new connection if WebSocket `readyState` is not `OPEN`

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -76,7 +76,9 @@ export function websocketStore(url, initialValue, socketOptions) {
 
   return {
     set(value) {
-      open().then(() => socket.send(JSON.stringify(value)));
+      const send = () => socket.send(JSON.stringify(value));
+      if (socket.readyState !== WebSocket.OPEN) open().then(send);
+      else send();
     },
     subscribe(subscription) {
       open();


### PR DESCRIPTION
This may not be the best approach, but at least it closes #314 