### PR TITLE
fix: do not open a new ws connection if already existing

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -47,8 +47,11 @@ export function websocketStore(url, initialValue, socketOptions) {
     }
 
     // we are still in the opening phase
-    if(openPromise) {
+    if (openPromise) {
       return openPromise;
+    }
+    if (socket) {
+      return
     }
 
     socket = new WebSocket(url, socketOptions);

--- a/tests/store-ava.mjs
+++ b/tests/store-ava.mjs
@@ -96,3 +96,21 @@ test.skip("failing subscription", async t => {
 
   t.true(true);
 });
+
+test("should not open a new ws connection if already existing", async t => {
+  let counter = 0;
+  t.context.wss.on('connection', () => { counter += 1 })
+  
+  const store = websocketStore(`ws://localhost:${t.context.port}`, "INITIAL");
+
+  const unsubscribe = store.subscribe(value => {});
+  await wait(300);
+  const anotherUnsubscribe = store.subscribe(value => {});
+  
+  await wait(50);
+
+  unsubscribe();
+  anotherUnsubscribe();
+
+  t.is(counter, 1)
+})


### PR DESCRIPTION
Hello @arlac77,
I've noticed that a new ws connection is opened on every subscription. This seems to happen only when waiting some time between the subscriptions, otherwise the opening state check hides this behavior. It's probably a regression introduced in https://github.com/arlac77/svelte-websocket-store/commit/b9c4e06ca5b799c91ba961562b13fe43069f7fc9. 

Does this make sense?